### PR TITLE
Remove redundant information in packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,7 +5,7 @@
 			"name": "Console API Snippets (JavaScript)",
 			"description": "JavaScript Console API Snippets for Sublime Text",
 			"author": "Michael Kühnel",
-			"details": "http://mischah.github.com/Console-API-Snippets/",
+			"details": "http://github.com/mischah/Console-API-Snippets",
 			"labels": ["snippets"],
 			"donate": "https://flattr.com/thing/953497/JavaScript-Console-API-Snippets-for-Sublime-Text",
 			"releases": [


### PR DESCRIPTION
Also add sublime_text version selector

We require these now due to the confusion it caused in the past
